### PR TITLE
corrigindo config para funcionar Reactotron no react native

### DIFF
--- a/src/config/ReactotronConfig.js
+++ b/src/config/ReactotronConfig.js
@@ -1,9 +1,10 @@
-import Reactotron from 'reactotron-react-native';
-import { reactotronRedux } from 'reactotron-redux';
-import sagaPlugin from 'reactotron-redux-saga';
+import Reactotron from "reactotron-react-native";
+import { reactotronRedux } from "reactotron-redux";
+import sagaPlugin from "reactotron-redux-saga";
 
 if (__DEV__) {
   const tron = Reactotron.configure()
+    .useReactNative()
     .use(reactotronRedux())
     .use(sagaPlugin())
     .connect();


### PR DESCRIPTION
olá,

Percebi que meus projetos instalados pelo template não estavam funcionando o Reactotron. Estava faltando o useReactNative() para poder funcionar.