### PR TITLE
fix(prettier): prevent endOfLine errors

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "trailingComma": "es5",
   "printWidth": 80,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
Add auto end-of-line rule to the prettier config to prevent errors like this:

![error example](https://user-images.githubusercontent.com/30202634/82517844-64ad5400-9af4-11ea-85e1-00b8667a734f.png)

I think this only happen on Windows. The solution is based on this [issue comment](https://github.com/prettier/eslint-plugin-prettier/issues/219#issuecomment-610262026).

I hope it be useful! 🙂🚀